### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ is still needed.
 
 ## Pages
 
-See [doc/README.md](doc/README.md) for a list of pages such as `/login`, `/join`, and others.
+See [p1/doc/README.md](p1/doc/README.md) for a list of pages such as `/login`, `/join`, and others.


### PR DESCRIPTION
## Summary
- fix the README.md path to the documentation

## Testing
- `./p1/mvnw -q -DskipTests=false test` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2827cbc83228294efa3c28a6be0